### PR TITLE
add workflow to push docker image for commits and tags

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -1,0 +1,52 @@
+name: 'Docker Push'
+
+on:
+  push:
+    # Dependabot has no access to the secrets that this workflow requires. So we
+    # skip running the workflow in branches that dependabot presumably created.
+    branches-ignore:
+      - 'dependabot/**'
+    # Trigger this workflow for all new releases that create a Git tag.
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker-push:
+    permissions:
+      contents: 'read'
+
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Authorize Container Registry'
+        uses: 'docker/login-action@v3.5.0'
+        with:
+          registry: '${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com'
+          username: '${{ secrets.AWS_ACCESS_KEY_ID }}'
+          password: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+
+      - name: 'Setup Build Environment'
+        uses: 'docker/setup-buildx-action@v3.11.1'
+
+      # We have to compute the image tag based on the kind of push that
+      # triggered this workflow. Ordinary commits should cause a Docker image
+      # tag to be pushed where the tag name is the commit sha of the push event.
+      # On the other hand, Github releases create Git tags, and if a tag
+      # creation event triggered this workflow, then we want the tag name to be
+      # the semver like release tag in the format v0.1.0.
+      - name: 'Compute Image Tag'
+        id: image
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Push Docker Image'
+        uses: 'docker/build-push-action@v6.18.0'
+        with:
+          push: true
+          tags: '${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ github.event.repository.name }}:${{ steps.image.outputs.tag }}'
+          build-args: |
+            SHA=${{ github.sha }}
+            TAG=${{ github.ref_name }}


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4711/run-splits-lite-in-cloudformation-and-deploy-via-kayron. This pushes the container image to our container registry after setting up the container repository and all credentials. The image here is only ~90 MB. Still a bit too much, but best we can do right now.

<img width="708" height="349" alt="Screenshot 2025-08-29 at 15 27 00" src="https://github.com/user-attachments/assets/96a1886f-03b8-4709-aacd-a6d980d2ba85" />
