### PR TITLE
Add Tempo mainnet support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "splits-lite",
       "dependencies": {
-        "@0xsplits/splits-kit": "2.3.1-alpha.0",
+        "@0xsplits/splits-kit": "2.4.0-alpha.0",
         "@radix-ui/react-tabs": "^1.1.1",
         "@rainbow-me/rainbowkit": "2.2.0",
         "@tanstack/react-query": "^5.59.16",
@@ -48,11 +48,11 @@
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
 
-    "@0xsplits/splits-kit": ["@0xsplits/splits-kit@2.3.1-alpha.0", "", { "dependencies": { "@0xsplits/splits-sdk": "6.4.1-alpha.0", "@0xsplits/splits-sdk-react": "4.3.1-alpha.0", "@headlessui/react": "^1.7.17", "@heroicons/react": "^2.0.18", "@hookform/error-message": "^2.0.1", "autoprefixer": "^10.4.16", "lodash": "^4.17.21", "postcss": "^8.4.31", "react-blockies": "^1.4.1", "react-hook-form": "^7.47.0", "react-number-format": "^5.3.1", "styled-components": "^6.1.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "react-dom": "17.x.x || 18.x.x", "viem": "2.x.x", "wagmi": "2.x.x" } }, "sha512-YN9YEbnnClirapryK/v2mrtpVY7Pw4/VxvXQ/cjAd+HBQWvBgbS5s/twJ6PjhVUrI2RFyTs1KwnhdrTfRNl7Jg=="],
+    "@0xsplits/splits-kit": ["@0xsplits/splits-kit@2.4.0-alpha.0", "", { "dependencies": { "@0xsplits/splits-sdk": "6.5.0-alpha.0", "@0xsplits/splits-sdk-react": "4.4.0-alpha.0", "@headlessui/react": "^1.7.17", "@heroicons/react": "^2.0.18", "@hookform/error-message": "^2.0.1", "autoprefixer": "^10.4.16", "lodash": "^4.17.21", "postcss": "^8.4.31", "react-blockies": "^1.4.1", "react-hook-form": "^7.47.0", "react-number-format": "^5.3.1", "styled-components": "^6.1.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "react-dom": "17.x.x || 18.x.x", "viem": "2.x.x", "wagmi": "2.x.x" } }, "sha512-r0c9IbH4jI/Rw8hkwDwaNI8AZt9l4T06+YuZPNw+CSY1OrYHHFY6QPTfXGYHIdFd0K96zcShH0JvglvPVThkzg=="],
 
-    "@0xsplits/splits-sdk": ["@0xsplits/splits-sdk@6.4.1-alpha.0", "", { "dependencies": { "@urql/core": "^4.3.0", "base-64": "^1.0.0", "graphql": "^16.8.1", "lodash": "^4.17.21" }, "peerDependencies": { "viem": "^2.0.0" }, "optionalPeers": ["viem"] }, "sha512-HDQElX801t/iydF07sR/CRfL6QOWMQMIxF6cztaz0CSi4DjbCOxLrX+cuRLqtd115HDJ5isStbnV69b4nTpPEg=="],
+    "@0xsplits/splits-sdk": ["@0xsplits/splits-sdk@6.5.0-alpha.0", "", { "dependencies": { "@urql/core": "^4.3.0", "base-64": "^1.0.0", "graphql": "^16.8.1", "lodash": "^4.17.21" }, "peerDependencies": { "viem": "^2.0.0" }, "optionalPeers": ["viem"] }, "sha512-c9BXI1iZCNqI4KW1yIdpB7pygO6pXjAS6uNwLjWTL+/gHZ+sSHsmKFyLvFAcSH8Q+26zQzkUJf89O6YKh2sgjA=="],
 
-    "@0xsplits/splits-sdk-react": ["@0xsplits/splits-sdk-react@4.3.1-alpha.0", "", { "dependencies": { "@0xsplits/splits-sdk": "6.4.1-alpha.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "viem": "^2.0.0" }, "optionalPeers": ["viem"] }, "sha512-9A/dSe6qfjdZCzx/FbxU4+k0tb6wqUls4kRDW2+IsRZ3GbSAuf6N5IcG4bDkmzeVKIQHRAyIM48vIr36hq/Xdg=="],
+    "@0xsplits/splits-sdk-react": ["@0xsplits/splits-sdk-react@4.4.0-alpha.0", "", { "dependencies": { "@0xsplits/splits-sdk": "6.5.0-alpha.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "viem": "^2.0.0" }, "optionalPeers": ["viem"] }, "sha512-SRVTOVrIM+tEZ/756f9+Fwtt5r1YIEMSgX4CzRpz8kIjUkClr5o0MFs7kMsqYGkTPDUuFJ7/+Npu8AVqlRM7YQ=="],
 
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "splits-lite",
       "dependencies": {
-        "@0xsplits/splits-kit": "2.4.0-alpha.0",
+        "@0xsplits/splits-kit": "2.4.0-alpha.1",
         "@radix-ui/react-tabs": "^1.1.1",
         "@rainbow-me/rainbowkit": "2.2.0",
         "@tanstack/react-query": "^5.59.16",
@@ -48,7 +48,7 @@
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
 
-    "@0xsplits/splits-kit": ["@0xsplits/splits-kit@2.4.0-alpha.0", "", { "dependencies": { "@0xsplits/splits-sdk": "6.5.0-alpha.0", "@0xsplits/splits-sdk-react": "4.4.0-alpha.0", "@headlessui/react": "^1.7.17", "@heroicons/react": "^2.0.18", "@hookform/error-message": "^2.0.1", "autoprefixer": "^10.4.16", "lodash": "^4.17.21", "postcss": "^8.4.31", "react-blockies": "^1.4.1", "react-hook-form": "^7.47.0", "react-number-format": "^5.3.1", "styled-components": "^6.1.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "react-dom": "17.x.x || 18.x.x", "viem": "2.x.x", "wagmi": "2.x.x" } }, "sha512-r0c9IbH4jI/Rw8hkwDwaNI8AZt9l4T06+YuZPNw+CSY1OrYHHFY6QPTfXGYHIdFd0K96zcShH0JvglvPVThkzg=="],
+    "@0xsplits/splits-kit": ["@0xsplits/splits-kit@2.4.0-alpha.1", "", { "dependencies": { "@0xsplits/splits-sdk": "6.5.0-alpha.0", "@0xsplits/splits-sdk-react": "4.4.0-alpha.0", "@headlessui/react": "^1.7.17", "@heroicons/react": "^2.0.18", "@hookform/error-message": "^2.0.1", "autoprefixer": "^10.4.16", "lodash": "^4.17.21", "postcss": "^8.4.31", "react-blockies": "^1.4.1", "react-hook-form": "^7.47.0", "react-number-format": "^5.3.1", "styled-components": "^6.1.0" }, "peerDependencies": { "react": "17.x.x || 18.x.x", "react-dom": "17.x.x || 18.x.x", "viem": "2.x.x", "wagmi": "2.x.x" } }, "sha512-Xdxv1AVY/bFb8fTSPTBQg1Ta+shxayRaZe2qFDlGUsxUstbjTyJ+/mkh1F1pX9L4u08VHt0jx8pwgdxyZiJ8EA=="],
 
     "@0xsplits/splits-sdk": ["@0xsplits/splits-sdk@6.5.0-alpha.0", "", { "dependencies": { "@urql/core": "^4.3.0", "base-64": "^1.0.0", "graphql": "^16.8.1", "lodash": "^4.17.21" }, "peerDependencies": { "viem": "^2.0.0" }, "optionalPeers": ["viem"] }, "sha512-c9BXI1iZCNqI4KW1yIdpB7pygO6pXjAS6uNwLjWTL+/gHZ+sSHsmKFyLvFAcSH8Q+26zQzkUJf89O6YKh2sgjA=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@0xsplits/splits-kit": "2.3.1-alpha.0",
+    "@0xsplits/splits-kit": "2.4.0-alpha.0",
     "@radix-ui/react-tabs": "^1.1.1",
     "@rainbow-me/rainbowkit": "2.2.0",
     "@tanstack/react-query": "^5.59.16",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@0xsplits/splits-kit": "2.4.0-alpha.0",
+    "@0xsplits/splits-kit": "2.4.0-alpha.1",
     "@radix-ui/react-tabs": "^1.1.1",
     "@rainbow-me/rainbowkit": "2.2.0",
     "@tanstack/react-query": "^5.59.16",

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -17,8 +17,19 @@ import {
   ronin,
   saigon,
   celo,
+  tempo,
   tempoModerato,
 } from 'viem/chains'
+
+const tempoWithMulticall = {
+  ...tempo,
+  contracts: {
+    ...(tempo.contracts ?? {}),
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11' as const,
+    },
+  },
+}
 
 const tempoModeratoWithMulticall = {
   ...tempoModerato,
@@ -47,6 +58,7 @@ export const SUPPORTED_CHAINS = [
   ronin,
   saigon,
   celo,
+  tempoWithMulticall,
   tempoModeratoWithMulticall,
   avalanche,
   hoodi,
@@ -114,6 +126,10 @@ export const rpcUrl = (key: string) => {
     [celo.id]: {
       chain: celo,
       url: `https://celo-mainnet.g.alchemy.com/v2/${key}`,
+    },
+    [tempo.id]: {
+      chain: tempoWithMulticall,
+      url: 'https://rpc.presto.tempo.xyz',
     },
     [tempoModerato.id]: {
       chain: tempoModeratoWithMulticall,

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -129,11 +129,11 @@ export const rpcUrl = (key: string) => {
     },
     [tempo.id]: {
       chain: tempoWithMulticall,
-      url: 'https://rpc.presto.tempo.xyz',
+      url: `https://tempo-mainnet.g.alchemy.com/v2/${key}`,
     },
     [tempoModerato.id]: {
       chain: tempoModeratoWithMulticall,
-      url: 'https://rpc.moderato.tempo.xyz',
+      url: `https://tempo-moderato.g.alchemy.com/v2/${key}`,
     },
     [avalanche.id]: {
       chain: avalanche,

--- a/src/constants/erc20.ts
+++ b/src/constants/erc20.ts
@@ -12,6 +12,7 @@ import {
   zora,
   worldchain,
   celo,
+  tempo,
   tempoModerato,
 } from 'viem/chains'
 
@@ -71,6 +72,13 @@ export const ERC_20_TOKEN_LIST_BY_CHAIN: { [key: number]: string[] } = {
   ],
   [avalanche.id]: [
     '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E', // USDC
+  ],
+  [tempo.id]: [
+    '0x20c0000000000000000000000000000000000000', // pathUSD
+    '0x20c000000000000000000000b9537d11c60e8b50', // USDC.e
+    '0x20c0000000000000000000001621e21f71cf12fb', // EURC.e
+    '0x20c00000000000000000000014f22ca97301eb73', // USDT0
+    '0x20c00000000000000000000031f228af88888888', // stcUSD
   ],
   [tempoModerato.id]: [
     '0x20c0000000000000000000000000000000000000',


### PR DESCRIPTION
## Summary
- Bump `@0xsplits/splits-kit` to `2.4.0-alpha.0` for Tempo mainnet support
- Add Tempo mainnet (chain id 4217) to supported chains with public RPC (`https://rpc.presto.tempo.xyz`)
- Add multicall3 contract wrapper (same pattern as Tempo testnet)
- Add Tempo mainnet token list from https://tokenlist.tempo.xyz/list/4217: pathUSD, USDC.e, EURC.e, USDT0, stcUSD

## Test plan
- [ ] Connect wallet and switch to Tempo mainnet
- [ ] Verify chain appears in network selector
- [ ] Create a split on Tempo mainnet
- [ ] Verify token list loads correctly in the UI
- [ ] Search for an existing split on Tempo mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)