### PR TITLE
ci: switch dependabot npm ecosystem to bun

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: "weekly"
       time: "04:00"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     open-pull-requests-limit: 10
     schedule:


### PR DESCRIPTION
## Summary
- Switches the Dependabot `npm` ecosystem to `bun` so Dependabot regenerates `bun.lock` natively.

## Why
Dependabot's `npm` ecosystem updates `package.json` but doesn't touch `bun.lock`. CI then runs `bun install`, which rewrites the lockfile, and the "Check Git Project" step fails with `found dirty files` (e.g. PR #107).

## Test plan
- [ ] Merge and wait for the next Dependabot run; verify lockfile is updated in-PR and `typescript` check passes without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)