### PR TITLE
Tune Dependabot config and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @r0ohafza
+* @0xSplits/frontend-eng

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,15 +14,39 @@ updates:
     schedule:
       interval: "weekly"
       time: "04:00"
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
       time: "04:00"
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
   - package-ecosystem: "bun"
     directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
       time: "04:00"
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary
- Reassign CODEOWNERS from `@r0ohafza` to the `@0xSplits/frontend-eng` team so review requests fan out to the team rather than a single person.
- Group minor + patch updates into a single PR per ecosystem (docker, github-actions, bun).
- Ignore semver-major bumps; the project is in maintenance mode so we don't want major-version churn.
- Add a 3-day cooldown before Dependabot opens a PR for a newly released version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)